### PR TITLE
Update callbacks.py for logging

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -8,7 +8,7 @@ import json
 import subprocess
 
 class Logger(object):
-    def __init__(self, filename="/edm.log"):
+    def __init__(self, filename="/var/log/edmrds.log"):
         self.terminal = sys.stdout
         self.log = open(filename, "a")
 
@@ -16,8 +16,7 @@ class Logger(object):
         self.terminal.write(message)
         self.log.write(message)
 
-#sys.stdout = Logger("/edm.log")
-#print "Hello world !" # this is should be saved in yourlogfilename.txt
+sys.stdout = Logger("/home/fpp/media/logs/edmrds.log")
 
 parser = argparse.ArgumentParser(description='RDS Setting Application')
 parser.add_argument('-t','--type', help='Input station name (8 characters max)', required=False)
@@ -26,24 +25,24 @@ parser.add_argument('-d','--data',help='Song name')
 args = parser.parse_args()
 
 if args.list:
-  #Tell the plugin that we should be registered for media
-   print "media"
+   #Tell the plugin that we should be registered for media
+   print("media")
 
 if args.type:
    # Look for our type of plugin, doubt this is even needed at all
    mytypearg = args.type
-   #print "My type args: %s" %mytypearg
+   print("My type args: %s" %mytypearg)
 
 if args.data:
    #get the json string from FPP
    mydataarg = args.data
-   print "My data args: %s" %mydataarg
+   print("My data args: %s" %mydataarg)
    data = json.loads(mydataarg)
    title = data['title'] 
-#   print "Title: %s" %title
+   print("Title: %s" %title)
    os.chdir("/home/fpp/media/plugins/edmrds/")
    directory = os.getcwd()
-#   print "Directory: %s" %directory
+   print("Directory: %s" %directory)
    #from subprocess import call
    #call(["rds-song.py", "-s %title"])
    subprocess.call(['/home/fpp/media/plugins/edmrds/rds-song.py', '-s', title])


### PR DESCRIPTION
1. Turned logging on by default
2. Removed the hello world as that will break the list functionality - fpp will read Hello... instead of media
3. Restored some print statements to enhance the debug log
4. Moved the debug log to /home/fpp/media/logs where the other fpp logs live
5. Tested and verified this is working with the latest v2.0 fpp code as of 9.3.2018
6. Changed the print statements to use parenthesis.  This will help towards make the code Python 3 friendly